### PR TITLE
Autoposition mode and hitTest fix 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+.derivedData/

--- a/AnchoredPopupExample/AnchoredPopupExample.xcodeproj/project.pbxproj
+++ b/AnchoredPopupExample/AnchoredPopupExample.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -417,7 +417,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/AnchoredPopupExample/AnchoredPopupExample.xcodeproj/project.pbxproj
+++ b/AnchoredPopupExample/AnchoredPopupExample.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -417,7 +417,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/AnchoredPopupExample/AnchoredPopupExample/Screens/ProfileView.swift
+++ b/AnchoredPopupExample/AnchoredPopupExample/Screens/ProfileView.swift
@@ -49,7 +49,7 @@ struct ProfileView: View {
                         .useAsPopupAnchor(id: "questions_view") {
                             QuestionsView()
                         } customize: {
-                            $0.position(.anchorRelative(.bottomTrailing))
+                            $0.position(.auto)
                                 .background(.none)
                                 .isBackgroundPassthrough(true)
                         }

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "AnchoredPopup",
     platforms: [
-        .iOS(.v17)
+        .iOS(.v16)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ dependencies: [
 
 ## Requirements
 
-* iOS 17.0+ 
+* iOS 16.0+ 
 
 ## Our other open source SwiftUI libraries
 [PopupView](https://github.com/exyte/PopupView) - Toasts and popups library    

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Customized example:
     $0.position(.anchorRelative(.bottomLeading))
         .background(.none)
         .isBackgroundPassthrough(true)
+        .openOnTap(true)
         .closeOnTap(false)
 }
 ```
@@ -55,6 +56,7 @@ Customized example:
     * `.screenRelative(UnitPoint)` - aligns the popup relative to the whole screen (default: `.center`)
     * `.absolute(UnitPoint, position: CGPoint)` - places the popup at an exact screen coordinate, with `UnitPoint` specifying which part of the popup aligns to that position
 - `animation` - appear/disappear animation   
+- `openOnTap` - enable/disable opening on tap on the anchor view (default: `true`)  
 - `closeOnTap` - enable/disable closing on tap on popup    
 - `closeOnTapOutside` - enable/disable closing on tap on popup's background     
 - `isBackgroundPassthrough` - enable/disable taps passing through the popup's background     

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Customized example:
 
 ### Optional parameters
 - `position` - determines where the popup appears on screen. Available options:
-    * `.anchorRelative(UnitPoint)` - aligns the popup relative to the anchor view at the corresponding proportion
+    * `.anchorRelative(UnitPoint, fitsScreen: Bool = true)` - aligns the popup relative to the anchor view at the corresponding proportion; when `fitsScreen` is `true` it will try to keep the popup within the screen safe area
+    * `.auto` - like `.anchorRelative(..., fitsScreen: true)`, but automatically picks the best `UnitPoint` (corner) to keep the popup within the safe area
     * `.screenRelative(UnitPoint)` - aligns the popup relative to the whole screen (default: `.center`)
     * `.absolute(UnitPoint, position: CGPoint)` - places the popup at an exact screen coordinate, with `UnitPoint` specifying which part of the popup aligns to that position
 - `animation` - appear/disappear animation   

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Customized example:
 
 ### Optional parameters
 - `position` - determines where the popup appears on screen. Available options:
-    * `.anchorRelative(UnitPoint, fitsScreen: Bool = true)` - aligns the popup relative to the anchor view at the corresponding proportion; when `fitsScreen` is `true` it will try to keep the popup within the screen safe area
-    * `.auto` - like `.anchorRelative(..., fitsScreen: true)`, but automatically picks the best `UnitPoint` (corner) to keep the popup within the safe area
+    * `.anchorRelative(UnitPoint, keepInScreenBounds: Bool = true)` - aligns the popup relative to the anchor view at the corresponding proportion; when `keepInScreenBounds` is `true` it will try to keep the popup within the screen safe area
+    * `.auto` - like `.anchorRelative(..., keepInScreenBounds: true)`, but automatically picks the best `UnitPoint` (corner) to keep the popup within the safe area
     * `.screenRelative(UnitPoint)` - aligns the popup relative to the whole screen (default: `.center`)
     * `.absolute(UnitPoint, position: CGPoint)` - places the popup at an exact screen coordinate, with `UnitPoint` specifying which part of the popup aligns to that position
 - `animation` - appear/disappear animation   

--- a/Sources/AnchoredPopup/AnchoredAnimationManager.swift
+++ b/Sources/AnchoredPopup/AnchoredAnimationManager.swift
@@ -158,14 +158,14 @@ struct TriggerButton<V>: ViewModifier where V: View {
                 }
             }
             .simultaneousGesture(
-                TapGesture().onEnded { gesture in
+                params.openOnTap ? TapGesture().onEnded { _ in
                     // trigger displaying animation only if popup is hidden
                     let currentState = AnchoredAnimationManager.shared.animations.first(where: { $0.id == id })?.state
                     if currentState == .hidden || currentState == nil {
                         hideKeyboard()
                         AnchoredAnimationManager.shared.changeStateForAnimation(for: id, state: .growing)
                     }
-                }
+                } : nil
             )
             .onReceive(AnchoredAnimationManager.shared.statePublisher(for: id)) { animation in
                 if animation?.state == .growing {

--- a/Sources/AnchoredPopup/AnchoredAnimationManager.swift
+++ b/Sources/AnchoredPopup/AnchoredAnimationManager.swift
@@ -326,9 +326,9 @@ fileprivate struct AnchoredAnimationView<V>: View where V: View {
         let ch = contentSize.floatHeight
 
         switch params.position {
-        case .anchorRelative(let p, let fitsScreen):
+        case .anchorRelative(let p, let keepInScreenBounds):
             let baseOffset = anchorRelativeBaseOffset(point: p, contentWidth: cw, contentHeight: ch)
-            guard fitsScreen else { return baseOffset }
+            guard keepInScreenBounds else { return baseOffset }
             return clampedOffsetKeepingPopupInBounds(
                 baseOffset: baseOffset,
                 contentWidth: cw,

--- a/Sources/AnchoredPopup/AnchoredAnimationManager.swift
+++ b/Sources/AnchoredPopup/AnchoredAnimationManager.swift
@@ -326,21 +326,26 @@ fileprivate struct AnchoredAnimationView<V>: View where V: View {
         let ch = contentSize.floatHeight
 
         switch params.position {
-        case .anchorRelative(let p):
-            let tw = triggerButtonFrame.floatWidth
-            let th = triggerButtonFrame.floatHeight
+        case .anchorRelative(let p, let fitsScreen):
+            let baseOffset = anchorRelativeBaseOffset(point: p, contentWidth: cw, contentHeight: ch)
+            guard fitsScreen else { return baseOffset }
+            return clampedOffsetKeepingPopupInBounds(
+                baseOffset: baseOffset,
+                contentWidth: cw,
+                contentHeight: ch,
+                bounds: safeAreaBounds()
+            )
 
-            // difference between centers
-            let w = cw/2 - tw/2
-            let h = ch/2 - th/2
-
-            // normalization: (0, 1) -> (1, -1)
-            let px = -2 * p.x + 1
-            let py = -2 * p.y + 1
-
-            // the content view center is currently same as anchor view
-            // +/- the difference between centers
-            return CGSize(width: w * px, height: h * py)
+        case .auto:
+            let bounds = safeAreaBounds()
+            let autoPoint = autoAnchorPoint(contentWidth: cw, contentHeight: ch, bounds: bounds)
+            let baseOffset = anchorRelativeBaseOffset(point: autoPoint, contentWidth: cw, contentHeight: ch)
+            return clampedOffsetKeepingPopupInBounds(
+                baseOffset: baseOffset,
+                contentWidth: cw,
+                contentHeight: ch,
+                bounds: bounds
+            )
 
         case .screenRelative(let p):
             let tx = triggerButtonFrame.floatMidX
@@ -372,5 +377,92 @@ fileprivate struct AnchoredAnimationView<V>: View where V: View {
             // cw/2 * px: align the specified unit point of popup with that position
             return CGSize(width: -tx + position.x + cw/2 * px, height: -ty + position.y + ch/2 * py)
         }
+    }
+
+    private func anchorRelativeBaseOffset(
+        point p: UnitPoint,
+        contentWidth cw: CGFloat,
+        contentHeight ch: CGFloat
+    ) -> CGSize {
+        let tw = triggerButtonFrame.floatWidth
+        let th = triggerButtonFrame.floatHeight
+
+        // difference between centers
+        let w = cw/2 - tw/2
+        let h = ch/2 - th/2
+
+        // normalization: (0, 1) -> (1, -1)
+        let px = -2 * p.x + 1
+        let py = -2 * p.y + 1
+
+        // the content view center is currently same as anchor view
+        // +/- the difference between centers
+        return CGSize(width: w * px, height: h * py)
+    }
+
+    private func clampedOffsetKeepingPopupInBounds(
+        baseOffset: CGSize,
+        contentWidth cw: CGFloat,
+        contentHeight ch: CGFloat,
+        bounds: CGRect
+    ) -> CGSize {
+        let triggerCenter = CGPoint(x: triggerButtonFrame.floatMidX, y: triggerButtonFrame.floatMidY)
+        let desiredCenter = CGPoint(x: triggerCenter.x + baseOffset.width, y: triggerCenter.y + baseOffset.height)
+
+        let halfW = cw / 2
+        let halfH = ch / 2
+
+        // If popup is larger than bounds, keep as much visible as possible by clamping using bounds half-size
+        let clampedHalfW = min(halfW, bounds.width / 2)
+        let clampedHalfH = min(halfH, bounds.height / 2)
+
+        let minCenterX = bounds.minX + clampedHalfW
+        let maxCenterX = bounds.maxX - clampedHalfW
+        let minCenterY = bounds.minY + clampedHalfH
+        let maxCenterY = bounds.maxY - clampedHalfH
+
+        let clampedCenter = CGPoint(
+            x: min(max(desiredCenter.x, minCenterX), maxCenterX),
+            y: min(max(desiredCenter.y, minCenterY), maxCenterY)
+        )
+
+        return CGSize(width: clampedCenter.x - triggerCenter.x, height: clampedCenter.y - triggerCenter.y)
+    }
+
+    private func autoAnchorPoint(contentWidth cw: CGFloat, contentHeight ch: CGFloat, bounds: CGRect) -> UnitPoint {
+        let candidates: [UnitPoint] = [.topLeading, .topTrailing, .bottomLeading, .bottomTrailing]
+        let triggerCenter = CGPoint(x: triggerButtonFrame.floatMidX, y: triggerButtonFrame.floatMidY)
+
+        // Stay on the same side of the screen as the anchor
+        let preferredX: CGFloat = triggerCenter.x < bounds.midX ? 0 : 1
+        let preferredY: CGFloat = triggerCenter.y < bounds.midY ? 0 : 1
+
+        func overflowScore(for point: UnitPoint) -> CGFloat {
+            let baseOffset = anchorRelativeBaseOffset(point: point, contentWidth: cw, contentHeight: ch)
+            let center = CGPoint(x: triggerCenter.x + baseOffset.width, y: triggerCenter.y + baseOffset.height)
+            let frame = CGRect(x: center.x - cw/2, y: center.y - ch/2, width: cw, height: ch)
+
+            let overflowLeft = max(bounds.minX - frame.minX, 0)
+            let overflowRight = max(frame.maxX - bounds.maxX, 0)
+            let overflowTop = max(bounds.minY - frame.minY, 0)
+            let overflowBottom = max(frame.maxY - bounds.maxY, 0)
+
+            // Minimize how much of the popup goes outside bounds
+            let overflow = overflowLeft + overflowRight + overflowTop + overflowBottom
+
+            // Choose the closest corner for the anchor
+            let tieBreaker = abs(point.x - preferredX) * 0.001 + abs(point.y - preferredY) * 0.001
+            return overflow + tieBreaker
+        }
+
+        return candidates.min(by: { overflowScore(for: $0) < overflowScore(for: $1) }) ?? .bottomLeading
+    }
+
+    private func safeAreaBounds() -> CGRect {
+        if let window = WindowManager.shared.windows[id] {
+            return window.bounds.inset(by: window.safeAreaInsets)
+        }
+
+        return UIScreen.main.bounds
     }
 }

--- a/Sources/AnchoredPopup/PublicAPI.swift
+++ b/Sources/AnchoredPopup/PublicAPI.swift
@@ -33,8 +33,8 @@ public class AnchoredPopup {
 // - MARK: Customization parameters
 
 public enum AnchoredPopupPosition {
-    case anchorRelative(_ point: UnitPoint, fitsScreen: Bool = true) // popup view will be aligned to anchor view at corresponding proportion
-    case auto // similar to `anchorRelative(..., fitsScreen: true)` but auto-picks the best anchor `UnitPoint` to keep the popup within safe area
+    case anchorRelative(_ point: UnitPoint, keepInScreenBounds: Bool = true) // popup view will be aligned to anchor view at corresponding proportion
+    case auto // similar to `anchorRelative(..., keepInScreenBounds: true)` but auto-picks the best anchor `UnitPoint` to keep the popup within safe area
     case screenRelative(_ point: UnitPoint = .center) // popup view will be aligned to whole screen
     case absolute(_ point: UnitPoint, position: CGPoint) // popup will be placed at exact screen position, with point specifying which part of popup aligns to that position
 }

--- a/Sources/AnchoredPopup/PublicAPI.swift
+++ b/Sources/AnchoredPopup/PublicAPI.swift
@@ -33,7 +33,8 @@ public class AnchoredPopup {
 // - MARK: Customization parameters
 
 public enum AnchoredPopupPosition {
-    case anchorRelative(_ point: UnitPoint) // popup view will be aligned to anchor view at corresponding proportion
+    case anchorRelative(_ point: UnitPoint, fitsScreen: Bool = true) // popup view will be aligned to anchor view at corresponding proportion
+    case auto // similar to `anchorRelative(..., fitsScreen: true)` but auto-picks the best anchor `UnitPoint` to keep the popup within safe area
     case screenRelative(_ point: UnitPoint = .center) // popup view will be aligned to whole screen
     case absolute(_ point: UnitPoint, position: CGPoint) // popup will be placed at exact screen position, with point specifying which part of popup aligns to that position
 }

--- a/Sources/AnchoredPopup/PublicAPI.swift
+++ b/Sources/AnchoredPopup/PublicAPI.swift
@@ -55,6 +55,9 @@ public struct PopupParameters {
     var position: AnchoredPopupPosition = .screenRelative()
     var animation: Animation = .easeIn(duration: 0.3)
 
+    /// Should open popup on tap on the anchor view
+    var openOnTap: Bool = true
+
     /// Should close on tap anywhere inside the popup
     var closeOnTap: Bool = true
 
@@ -76,6 +79,13 @@ public struct PopupParameters {
     public func animation(_ animation: Animation) -> PopupParameters {
         var params = self
         params.animation = animation
+        return params
+    }
+
+    /// Should open popup on tap on the anchor view - default is `true`
+    public func openOnTap(_ openOnTap: Bool) -> PopupParameters {
+        var params = self
+        params.openOnTap = openOnTap
         return params
     }
 

--- a/Sources/AnchoredPopup/Utils.swift
+++ b/Sources/AnchoredPopup/Utils.swift
@@ -31,7 +31,6 @@ struct ButtonFramePreferenceKey: PreferenceKey {
 
 // MARK: - AnimatedBackgroundView
 
-
 struct AnimatedBackgroundView: View {
     @Binding var id: String
     var background: AnchoredPopupBackground
@@ -60,7 +59,7 @@ struct AnimatedBackgroundView: View {
                 }
             }
             
-            PopupBackgroundFrameMarker()
+            PopupHitTestingBackground()
                 .ignoresSafeArea()
         }
     }
@@ -87,7 +86,7 @@ struct AnimatedBackgroundView: View {
 }
 
 /// A special view to handle hit-testing on background parts of popup content
-struct PopupBackgroundFrameMarker: UIViewRepresentable {
+struct PopupHitTestingBackground: UIViewRepresentable {
     func makeUIView(context: Context) -> UIView {
         let view = UIView()
         view.backgroundColor = .clear

--- a/Sources/AnchoredPopup/Utils.swift
+++ b/Sources/AnchoredPopup/Utils.swift
@@ -31,6 +31,7 @@ struct ButtonFramePreferenceKey: PreferenceKey {
 
 // MARK: - AnimatedBackgroundView
 
+
 struct AnimatedBackgroundView: View {
     @Binding var id: String
     var background: AnchoredPopupBackground
@@ -38,24 +39,29 @@ struct AnimatedBackgroundView: View {
     @State private var animatableOpacity: CGFloat = 0
 
     var body: some View {
-        Group {
-            switch background {
-            case .none:
-                EmptyView()
-            case .color(let color):
-                color
-            case .blur(let radius):
-                Blur(radius: radius)
-            case .view(let anyView):
-                anyView
+        ZStack {
+            Group {
+                switch background {
+                case .none:
+                    EmptyView()
+                case .color(let color):
+                    color
+                case .blur(let radius):
+                    Blur(radius: radius)
+                case .view(let anyView):
+                    anyView
+                }
             }
-        }
-        .ignoresSafeArea()
-        .opacity(animatableOpacity)
-        .onReceive(AnchoredAnimationManager.shared.statePublisher(for: id)) { animation in
-            if let animation {
-                setupAndLaunchAnimation(animation)
+            .ignoresSafeArea()
+            .opacity(animatableOpacity)
+            .onReceive(AnchoredAnimationManager.shared.statePublisher(for: id)) { animation in
+                if let animation {
+                    setupAndLaunchAnimation(animation)
+                }
             }
+            
+            PopupBackgroundFrameMarker()
+                .ignoresSafeArea()
         }
     }
 
@@ -78,6 +84,18 @@ struct AnimatedBackgroundView: View {
     private func setDisplayedState() {
         animatableOpacity = 1
     }
+}
+
+/// A special view to handle hit-testing on background parts of popup content
+struct PopupBackgroundFrameMarker: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = .clear
+        view.isUserInteractionEnabled = false
+        return view
+    }
+    
+    func updateUIView(_ uiView: UIView, context: Context) {}
 }
 
 // MARK: - IntRect

--- a/Sources/AnchoredPopup/WindowManager.swift
+++ b/Sources/AnchoredPopup/WindowManager.swift
@@ -53,23 +53,33 @@ class UIPassthroughWindow: UIWindow {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        if let vc = self.rootViewController {
-            vc.view.layoutSubviews() // otherwise the frame is as if the popup is still outside the screen
-            if let _ = isTouchInsideSubview(point: point, vc: vc.view) {
-                // pass tap to this UIPassthroughVC
-                let farthestDescendent = super.hitTest(point, with: event)
-                return farthestDescendent
-            }
-        }
-        if closeOnTapOutside {
-            AnchoredAnimationManager.shared.changeStateForAnimation(for: id, state: .shrinking)
-        }
-        if isPassthrough {
+        guard let vc = self.rootViewController else {
             return nil // pass to next window
         }
-        return self.rootViewController?.view
+        
+        vc.view.layoutIfNeeded() // otherwise the frame is as if the popup is still outside the screen
+        
+        let layerHitTestResult = vc.view.layer.hitTest(vc.view.convert(point, from: self))
+        let superlayerDelegateName = layerHitTestResult?.superlayer?.delegate.map { String(describing: type(of: $0)) }
+        let isTappedOnBackground = superlayerDelegateName?.contains(String(describing: PopupBackgroundFrameMarker.self)) ?? false
+        
+        if isTappedOnBackground {
+            if closeOnTapOutside {
+                AnchoredAnimationManager.shared.changeStateForAnimation(for: id, state: .shrinking)
+            }
+            
+            if isPassthrough {
+                return nil // pass to next window
+            }
+            return vc.view
+        }
+        
+        // pass tap to this
+        let farthestDescendent = super.hitTest(point, with: event)
+        return farthestDescendent
+        
     }
 
     private func isTouchInsideSubview(point: CGPoint, vc: UIView) -> UIView? {
@@ -79,51 +89,5 @@ class UIPassthroughWindow: UIWindow {
             }
         }
         return nil
-    }
-}
-
-class UIPassthroughVC<Content: View>: UIHostingController<Content> {
-
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        // Check if any touch is inside one of the subviews, if so, ignore it
-        if !isTouchInsideSubview(touches) {
-            // If touch is not inside any subview, pass the touch to the next responder
-            super.touchesBegan(touches, with: event)
-        }
-    }
-
-    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
-        if !isTouchInsideSubview(touches) {
-            super.touchesMoved(touches, with: event)
-        }
-    }
-
-    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-        if !isTouchInsideSubview(touches) {
-            super.touchesEnded(touches, with: event)
-        }
-    }
-
-    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
-        if !isTouchInsideSubview(touches) {
-            super.touchesCancelled(touches, with: event)
-        }
-    }
-
-    // Helper function to determine if any touch is inside a subview
-    private func isTouchInsideSubview(_ touches: Set<UITouch>) -> Bool {
-        guard let touch = touches.first else {
-            return false
-        }
-
-        let touchLocation = touch.location(in: self.view)
-
-        // Iterate over all subviews to check if the touch is inside any of them
-        for subview in self.view.subviews {
-            if subview.frame.contains(touchLocation) {
-                return true
-            }
-        }
-        return false
     }
 }

--- a/Sources/AnchoredPopup/WindowManager.swift
+++ b/Sources/AnchoredPopup/WindowManager.swift
@@ -63,9 +63,9 @@ class UIPassthroughWindow: UIWindow {
         
         let layerHitTestResult = vc.view.layer.hitTest(vc.view.convert(point, from: self))
         let superlayerDelegateName = layerHitTestResult?.superlayer?.delegate.map { String(describing: type(of: $0)) }
-        let isTappedOnBackground = superlayerDelegateName?.contains(String(describing: PopupBackgroundFrameMarker.self)) ?? false
+        let didTapBackground = superlayerDelegateName?.contains(String(describing: PopupHitTestingBackground.self)) ?? false
         
-        if isTappedOnBackground {
+        if didTapBackground {
             if closeOnTapOutside {
                 AnchoredAnimationManager.shared.changeStateForAnimation(for: id, state: .shrinking)
             }
@@ -79,7 +79,6 @@ class UIPassthroughWindow: UIWindow {
         // pass tap to this
         let farthestDescendent = super.hitTest(point, with: event)
         return farthestDescendent
-        
     }
 
     private func isTouchInsideSubview(point: CGPoint, vc: UIView) -> UIView? {

--- a/Sources/AnchoredPopup/WindowManager.swift
+++ b/Sources/AnchoredPopup/WindowManager.swift
@@ -59,7 +59,8 @@ class UIPassthroughWindow: UIWindow {
             vc.view.layoutSubviews() // otherwise the frame is as if the popup is still outside the screen
             if let _ = isTouchInsideSubview(point: point, vc: vc.view) {
                 // pass tap to this UIPassthroughVC
-                return vc.view
+                let farthestDescendent = super.hitTest(point, with: event)
+                return farthestDescendent
             }
         }
         if closeOnTapOutside {


### PR DESCRIPTION
1. This PR fixes incorrect hit-testing/passthrough behavior on iOS 16.0-26 for AnchoredPopup windows by reliably distinguishing taps on popup background (including EmptyView) vs taps on popup content. 

2. It adds `fitsScreen: Bool` option for `anchorRelative` position. When `fitsScreen` is `true` it will try to keep the popup within the screen safe area

3. Also, it adds '.auto' positioning mode which works  like `.anchorRelative(..., fitsScreen: true)`, but automatically picks the best `UnitPoint` (corner) to keep the popup within the safe area

4. Downgrades min iOS version to 16 as it works fine on it.

Regarding the hit testing thing:

**Problem**
UIKit view hit-testing in an overlay UIWindow can return inconsistent results for SwiftUI-hosted hierarchies (especially when the background is .none/EmptyView). This caused taps on content to be misclassified as "outside/background" (or vice versa), breaking closeOnTapOutside and passthrough behavior.

**Solution**

- Add a lightweight SwiftUI -> UIKit marker: PopupBackgroundFrameMarker (a UIViewRepresentable backed by a clear UIView).

- Insert it into AnimatedBackgroundView so it always exists for the popup background layer

- Update UIPassthroughWindow.hitTest to use CALayer.hitTest and inspect the superlayer.delegate chain to detect when the hit came from the background marker

- If tapped on background -> optionally dismiss (closeOnTapOutside), and either passthrough (nil) or swallow

- If tapped on content -> return super.hitTest(...) to preserve normal interaction (deepest descendant view)